### PR TITLE
Update RTObject.cs

### DIFF
--- a/Streaming/RTObject.cs
+++ b/Streaming/RTObject.cs
@@ -1,8 +1,9 @@
-﻿// Unity SDK for Qualisys Track Manager. Copyright 2015 Qualisys AB
+// Unity SDK for Qualisys Track Manager. Copyright 2015 Qualisys AB
 //
 using UnityEngine;
 using System.Collections;
 using QTMRealTimeSDK;
+
 
 namespace QualisysRealTime.Unity
 {
@@ -11,6 +12,8 @@ namespace QualisysRealTime.Unity
         public string ObjectName = "Put QTM 6DOF object name here";
         public Vector3 PositionOffset = new Vector3(0, 0, 0);
         public Vector3 EulerOffset = new Vector3(0, 0, 0);
+        public bool DisableRotation = false;
+        public bool DisableTranslation = false;
 
         private RTClient rtClient;
 
@@ -30,10 +33,16 @@ namespace QualisysRealTime.Unity
             {
                 if (body.Position.magnitude > 0) //just to avoid error when position is NaN
                 {
-                    transform.position = body.Position + PositionOffset;
-                    if (transform.parent) transform.position += transform.parent.position;
-                    transform.rotation = body.Rotation * Quaternion.Euler(EulerOffset);
-                    if (transform.parent) transform.rotation *= transform.parent.rotation;
+					if (DisableTranslation != true) //checking for DisableTranslation if other Translational data available
+                    {
+                        transform.position = body.Position + PositionOffset;
+                        if (transform.parent) transform.position += transform.parent.position;
+                    }
+					if (DisableRotation != true)//checking for DisableRotation if other Rotational data available
+                    {
+                        transform.rotation = body.Rotation * Quaternion.Euler(EulerOffset);
+                        if (transform.parent) transform.rotation *= transform.parent.rotation;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Adding 2 Public bool variables DisableRotation and DisableTranslation available in Unity coding UI to disable Translational/Rotational Data from RTObjects if other Translational/Rotational data available from other source (like Oculus Rift magnitometer for example)
