### PR TITLE
RTNetwork.cs: Add workaround for Unity on Mac

### DIFF
--- a/RTClientSDK.Net/RTNetwork.cs
+++ b/RTClientSDK.Net/RTNetwork.cs
@@ -274,7 +274,18 @@ namespace QTMRealTimeSDK.Network
                     {
                         if (ip.Address.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
                         {
-                            IPAddress broadcastAddress = ip.Address.GetBroadcastAddress(ip.IPv4Mask);
+                            // Workaround if IPv4Mask is not implemented (e.g. Unity on Mac)
+                            IPAddress ipMask;
+                            try
+                            {
+                                ipMask = ip.IPv4Mask;
+                            }
+                            catch (NotImplementedException ex)
+                            {
+                                ipMask = IPAddress.Parse("255.255.255.0");
+                            }
+                            
+                            IPAddress broadcastAddress = ip.Address.GetBroadcastAddress(ipMask);
                             if (broadcastAddress == null)
                                 continue;
 


### PR DESCRIPTION
IPv4Mask is not implemented when using the Plugin in Unity on Mac. This workaround defaults back to a mask of 255.255.255.0 in this case.