### PR TITLE
Update RTClient.cs

### DIFF
--- a/Qualisys/QTM-Unity-Realtime-Streaming/Helpers/RTClient.cs
+++ b/Qualisys/QTM-Unity-Realtime-Streaming/Helpers/RTClient.cs
@@ -392,6 +392,8 @@ namespace QualisysRealTime.Unity
             mGazeVectors.Clear();
             mAnalogChannels.Clear();
             mStreamingStatus = false;
+            mProtocol.RealTimeDataCallback -= Process;
+            mProtocol.EventDataCallback -= Events;
             mProtocol.StreamFramesStop();
             mProtocol.StopStreamListen();
             mProtocol.Disconnect();


### PR DESCRIPTION
Fixed an issue where Process gets called multiple times per package after reconnecting.
Calling Disconnect while not connected might cause an issue now. I think this is ok since it would mean you are using the object incorrectly.